### PR TITLE
fix: ensure Supabase client is fully initialized before use

### DIFF
--- a/app/(auth)/auth/confirm/route.ts
+++ b/app/(auth)/auth/confirm/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
   redirectTo.searchParams.delete('type')
 
   if (token_hash && type) {
-    const supabase = createClient()
+    const supabase = await createClient()
 
     const { error } = await supabase.auth.verifyOtp({
       type,


### PR DESCRIPTION
await the result of createClient() to ensure the Supabase client is properly initialized before accessing auth.