### PR TITLE
Add thread category support across components

### DIFF
--- a/app/(landingPage)/components/ThreadRow.tsx
+++ b/app/(landingPage)/components/ThreadRow.tsx
@@ -7,29 +7,30 @@ import { format } from 'date-fns';
 import { ThreadData } from '@/types/forum';
 
 export function ThreadRow({ thread }: { thread: ThreadData }) {
-  // Use the avatar_url if available, otherwise fallback to the vercel.sh avatar
-  // Adding null check to ensure we don't access properties of undefined
-  const avatarUrl = thread.author?.account_avatar_url || `https://avatar.vercel.sh/${thread.author?.account_username || 'user'}`;
+  // Access author data from thread object
+  const username = thread.author?.account_username || 'Anonymous';
+  const avatarUrl = thread.author?.account_avatar_url || `https://avatar.vercel.sh/${username}`;
+  const initial = username.charAt(0).toUpperCase();
 
   return (
     <Link href={`/thread/${thread.thread_id}`}>
       <div className="flex items-start gap-3 p-3 hover:bg-accent rounded-md transition-colors cursor-pointer">
         {/* Avatar on the leftmost */}
         <Avatar className="h-10 w-10 flex-shrink-0">
-          <AvatarImage src={avatarUrl} />
-          <AvatarFallback className="text-xs">{thread.author?.account_username ? thread.author.account_username.charAt(0).toUpperCase() : 'U'}</AvatarFallback>
+          <AvatarImage src={avatarUrl} alt={username} />
+          <AvatarFallback className="text-xs">{initial}</AvatarFallback>
         </Avatar>
 
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <Badge variant="secondary" className="text-xs">
-              Thread
+              {thread.thread_category || 'General'}
             </Badge>
             <span className="text-sm font-semibold truncate">{thread.thread_title}</span>
           </div>
 
           <div className="text-xs text-muted-foreground mt-1">
-            Posted by {thread.author?.account_username || 'Anonymous'} • {format(new Date(thread.thread_created), 'MMM d, yyyy')}
+            Posted by {username} • {format(new Date(thread.thread_created), 'MMM d, yyyy')}
           </div>
         </div>
       </div>

--- a/app/forums/subforum/[subforumId]/components/SubforumTopics.tsx
+++ b/app/forums/subforum/[subforumId]/components/SubforumTopics.tsx
@@ -15,6 +15,7 @@ interface DatabaseThread {
   thread_title: string;
   thread_created: string;
   thread_content: string;
+  thread_category?: string;
   comment_count: number;
   author: {
     account_username: string | null;
@@ -45,6 +46,7 @@ export function SubforumTopics({ subforumId }: SubforumTopicsProps) {
             thread_title,
             thread_created,
             thread_content,
+            thread_category,
             author:author_id(account_username, account_email),
             comment_count:Comment(count)
           `
@@ -64,7 +66,7 @@ export function SubforumTopics({ subforumId }: SubforumTopicsProps) {
               name: thread.author?.account_username || 'Anonymous',
               avatar: `https://ui-avatars.com/api/?name=${encodeURIComponent(thread.author?.account_username || 'A')}&background=random`
             },
-            tag: 'Discussion',
+            tag: thread.thread_category || 'Discussion',
             createdAt: new Date(thread.thread_created),
             replies: thread.comment_count || 0,
             views: 0

--- a/app/post-thread/components/PostThread.tsx
+++ b/app/post-thread/components/PostThread.tsx
@@ -175,6 +175,7 @@ const PostThread = () => {
           {
             thread_title: formData.title,
             thread_content: formData.content,
+            thread_category: formData.category,
             subforum_id: selectedSubforumId,
             thread_deleted: false,
             thread_created: new Date().toISOString(),

--- a/app/thread/[threadId]/components/ThreadContent.tsx
+++ b/app/thread/[threadId]/components/ThreadContent.tsx
@@ -52,6 +52,7 @@ export default function ThreadContent({ thread, optimizeImages, openLightbox }: 
       {/* Main Thread Card */}
       <Card className="mb-6 sm:mb-8 mt-3 sm:mt-4">
         <CardHeader className="px-3 sm:px-6 py-3 sm:py-4">
+          <div className="flex items-center gap-2 mb-2">{thread.thread_category && <span className="text-xs font-semibold bg-gray-200 px-4 py-0.5 rounded-sm">{thread.thread_category}</span>}</div>
           <CardTitle className="text-lg sm:text-xl md:text-2xl break-words">{thread.thread_title}</CardTitle>
         </CardHeader>
         <CardContent className="px-3 sm:px-6 py-3 sm:py-4">

--- a/app/thread/[threadId]/components/interfaces.ts
+++ b/app/thread/[threadId]/components/interfaces.ts
@@ -23,6 +23,7 @@ export interface Thread {
   thread_id: number;
   thread_title: string;
   thread_content: string;
+  thread_category?: string;
   thread_created: string;
   thread_deleted: boolean;
   author: {

--- a/app/thread/[threadId]/edit/components/EditThreadForm.tsx
+++ b/app/thread/[threadId]/edit/components/EditThreadForm.tsx
@@ -16,6 +16,7 @@ interface Thread {
   thread_id: number;
   thread_title: string;
   thread_content: string;
+  thread_category?: string;
   subforum_id: number;
   subforum: {
     subforum_name: string;
@@ -32,13 +33,14 @@ export default function EditThreadForm({ thread, user }: EditThreadFormProps) {
   const router = useRouter();
   const [title, setTitle] = useState(thread.thread_title);
   const [content, setContent] = useState(thread.thread_content);
+  const [category, setCategory] = useState(thread.thread_category || '');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!title.trim() || !content.trim()) {
-      toast.error('Title and content are required');
+    if (!title.trim() || !content.trim() || !category.trim()) {
+      toast.error('Title, content and category are required');
       return;
     }
 
@@ -53,6 +55,7 @@ export default function EditThreadForm({ thread, user }: EditThreadFormProps) {
         .update({
           thread_title: title,
           thread_content: content,
+          thread_category: category,
           thread_modified: new Date().toISOString()
         })
         .eq('thread_id', thread.thread_id)
@@ -83,6 +86,18 @@ export default function EditThreadForm({ thread, user }: EditThreadFormProps) {
         <div className="space-y-2">
           <Label htmlFor="title">Title</Label>
           <Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Thread Title" required />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="category">Category</Label>
+          <select id="category" value={category} onChange={(e) => setCategory(e.target.value)} className="w-full p-2 border rounded-lg border-gray-300" required>
+            <option value="">Select a category</option>
+            <option value="Help">Help</option>
+            <option value="Discussion">Discussion</option>
+            <option value="Question">Question</option>
+            <option value="Tutorial">Tutorial</option>
+            <option value="News">News</option>
+          </select>
         </div>
 
         <div className="space-y-2">

--- a/components/ThreadRow.tsx
+++ b/components/ThreadRow.tsx
@@ -10,6 +10,7 @@ interface ThreadRowProps {
     thread_id: number;
     thread_title: string;
     thread_created: string;
+    thread_category?: string;
     author: {
       account_username: string | null;
       account_email: string | null;
@@ -45,7 +46,7 @@ const ThreadRow = ({ thread }: ThreadRowProps) => {
             <div className="flex items-center">
               <div>
                 <div className="flex justify-start items-center gap-2">
-                  <span className="text-xs font-semibold bg-gray-200 px-4 py-0.5 rounded-sm">Discussion</span>
+                  <span className="text-xs font-semibold bg-gray-200 px-4 py-0.5 rounded-sm">{thread.thread_category || 'Discussion'}</span>
                   <h3 className="text-md font-semibold">{thread.thread_title}</h3>
                 </div>
                 <div className="text-xs text-semibold text-gray-500">

--- a/prisma/migrations/20250502161738_update_post_thread_schema/migration.sql
+++ b/prisma/migrations/20250502161738_update_post_thread_schema/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Thread" ADD COLUMN     "thread_category" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,7 @@
     thread_id        Int            @id @default(autoincrement())
     thread_title     String
     thread_content   String
+    thread_category  String?        // Added thread_category field as optional
     thread_isDeleted Boolean        @default(false) @map("thread_deleted")
     thread_created   DateTime       @default(now()) @map("thread_created") @db.Timestamptz(6)
     thread_modified  DateTime       @updatedAt @map("thread_modified") @db.Timestamptz(6)
@@ -112,7 +113,7 @@
     @@map("thread_image")
   }
 
-  model notifications {
+  model Notification {
     notification_id Int              @id @default(autoincrement())
     recipient_id    String           @db.Uuid // Who should receive the notification
     sender_id       String           @db.Uuid // Who triggered the notification

--- a/repositories/thread-repository.ts
+++ b/repositories/thread-repository.ts
@@ -16,8 +16,9 @@ export class ThreadRepository {
         thread_id,
         thread_title,
         thread_created,
+        thread_category,
         comments:Comment(count),
-        author:author_id(
+        author:Account!author_id(
           account_username,
           account_email,
           account_avatar_url
@@ -43,10 +44,11 @@ export class ThreadRepository {
       thread_id: thread.thread_id,
       thread_title: thread.thread_title,
       thread_created: thread.thread_created,
+      thread_category: thread.thread_category,
       author: {
-        account_username: thread.author[0]?.account_username || null,
-        account_email: thread.author[0]?.account_email || null,
-        account_avatar_url: thread.author[0]?.account_avatar_url || null
+        account_username: thread.author?.account_username || null,
+        account_email: thread.author?.account_email || null,
+        account_avatar_url: thread.author?.account_avatar_url || null
       },
       comments: thread.comments || []
     }));

--- a/types/forum.ts
+++ b/types/forum.ts
@@ -8,6 +8,7 @@ export interface ThreadData {
   thread_id: number;
   thread_title: string;
   thread_created: string;
+  thread_category?: string;
   author: ThreadAuthor;
   comments: { count: number }[];
 }


### PR DESCRIPTION
- Introduced `thread_category` field in the Prisma schema and updated relevant interfaces.
- Modified `ThreadRow`, `SubforumTopics`, `PostThread`, and `EditThreadForm` components to handle thread categories.
- Updated UI to display thread categories in `ThreadContent` and `ThreadRow` for better context.
- Ensured category selection is required in the thread creation and editing forms for improved data integrity.